### PR TITLE
PayPay 決済画面に遷移実装

### DIFF
--- a/lib/config/router.g.dart
+++ b/lib/config/router.g.dart
@@ -6,7 +6,7 @@ part of 'router.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$routerHash() => r'2911a56a93bff450efb2591c0956338e6af454a7';
+String _$routerHash() => r'9509814763286086d4c94bc64484490ecfc52644';
 
 /// See also [router].
 @ProviderFor(router)

--- a/lib/feature/merchandise/presentation/merchandise_page.dart
+++ b/lib/feature/merchandise/presentation/merchandise_page.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../config/logger.dart';
 import '../../manage/presentation/manage_page.dart';
+import '../../payment/application/payment_service.dart';
 
 class MerchandisePage extends ConsumerStatefulWidget {
   const MerchandisePage({super.key});
@@ -16,6 +19,13 @@ class MerchandisePage extends ConsumerStatefulWidget {
 }
 
 class MerchandisePageState extends ConsumerState<MerchandisePage> {
+  Future<void> transitionSite(String url) async {
+    final uri = Uri.parse(url);
+    if (!await launchUrl(uri)) {
+      throw Exception('Could not launch $uri');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -30,8 +40,15 @@ class MerchandisePageState extends ConsumerState<MerchandisePage> {
           ),
         ],
       ),
-      body: const Center(
-        child: Text('Merchandise Page'),
+      body: ElevatedButton(
+        onPressed: () async {
+          final link = await ref
+              .read(paymentServiceProvider.notifier)
+              .generatePayPayLink();
+          logger.i(link);
+          await transitionSite(link);
+        },
+        child: const Text('Go to Manage Page'),
       ),
     );
   }

--- a/lib/feature/payment/application/payment_service.dart
+++ b/lib/feature/payment/application/payment_service.dart
@@ -1,0 +1,58 @@
+import 'dart:convert';
+import 'dart:math';
+
+import 'package:http/http.dart' as http;
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+
+import '../domain/purchase_data.dart';
+import '../domain/transition_url.dart';
+
+part 'payment_service.g.dart';
+
+@riverpod
+class PaymentService extends _$PaymentService {
+  @override
+  void build() {}
+
+  String generateRandomId() {
+    final random = Random();
+    // 100000000 〜 999999999
+    final firstRandom = random.nextInt(900000000) + 100000000;
+    // 10000 〜 99999
+    final secondRandom = random.nextInt(90000) + 10000;
+
+    return '$firstRandom$secondRandom';
+  }
+
+  // https://us-central1-sampledetarameapp.cloudfunctions.net/generatePayPayLink
+  Future<String> generatePayPayLink() async {
+    final url = Uri.parse(
+      'https://us-central1-sampledetarameapp.cloudfunctions.net/generatePayPayLink',
+    );
+
+    final response = await http.post(
+      url,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: jsonEncode({
+        'purchaseData': PurchaseData(
+          merchantPaymentId: generateRandomId(),
+          productName: 'ホゲ',
+          productEnName: 'hoge',
+          description: 'hoge huga piyo',
+          price: 122,
+        ),
+      }),
+    );
+
+    if (response.statusCode == 200) {
+      final responseData = TransitionUrl.fromJson(
+        json.decode(response.body) as Map<String, dynamic>,
+      );
+      return responseData.transitionUrl;
+    } else {
+      throw Exception('Failed to generate PayPay link');
+    }
+  }
+}

--- a/lib/feature/payment/application/payment_service.g.dart
+++ b/lib/feature/payment/application/payment_service.g.dart
@@ -1,0 +1,26 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'payment_service.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$paymentServiceHash() => r'7b29c5a98697592db44b3f04d41fc5865bef31e9';
+
+/// See also [PaymentService].
+@ProviderFor(PaymentService)
+final paymentServiceProvider =
+    AutoDisposeNotifierProvider<PaymentService, void>.internal(
+  PaymentService.new,
+  name: r'paymentServiceProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$paymentServiceHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$PaymentService = AutoDisposeNotifier<void>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member

--- a/lib/feature/payment/domain/purchase_data.dart
+++ b/lib/feature/payment/domain/purchase_data.dart
@@ -1,0 +1,18 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'purchase_data.freezed.dart';
+part 'purchase_data.g.dart';
+
+// functions の HTTP リクエストで使用するデータクラス
+@freezed
+class PurchaseData with _$PurchaseData {
+  const factory PurchaseData({
+    required String merchantPaymentId,
+    required String productName,
+    required String productEnName,
+    required String description,
+    required double price,
+  }) = _PurchaseData;
+
+  factory PurchaseData.fromJson(Map<String, dynamic> json) => _$PurchaseDataFromJson(json);
+}

--- a/lib/feature/payment/domain/purchase_data.freezed.dart
+++ b/lib/feature/payment/domain/purchase_data.freezed.dart
@@ -1,0 +1,240 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'purchase_data.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+PurchaseData _$PurchaseDataFromJson(Map<String, dynamic> json) {
+  return _PurchaseData.fromJson(json);
+}
+
+/// @nodoc
+mixin _$PurchaseData {
+  String get merchantPaymentId => throw _privateConstructorUsedError;
+  String get productName => throw _privateConstructorUsedError;
+  String get productEnName => throw _privateConstructorUsedError;
+  String get description => throw _privateConstructorUsedError;
+  double get price => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $PurchaseDataCopyWith<PurchaseData> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $PurchaseDataCopyWith<$Res> {
+  factory $PurchaseDataCopyWith(
+          PurchaseData value, $Res Function(PurchaseData) then) =
+      _$PurchaseDataCopyWithImpl<$Res, PurchaseData>;
+  @useResult
+  $Res call(
+      {String merchantPaymentId,
+      String productName,
+      String productEnName,
+      String description,
+      double price});
+}
+
+/// @nodoc
+class _$PurchaseDataCopyWithImpl<$Res, $Val extends PurchaseData>
+    implements $PurchaseDataCopyWith<$Res> {
+  _$PurchaseDataCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? merchantPaymentId = null,
+    Object? productName = null,
+    Object? productEnName = null,
+    Object? description = null,
+    Object? price = null,
+  }) {
+    return _then(_value.copyWith(
+      merchantPaymentId: null == merchantPaymentId
+          ? _value.merchantPaymentId
+          : merchantPaymentId // ignore: cast_nullable_to_non_nullable
+              as String,
+      productName: null == productName
+          ? _value.productName
+          : productName // ignore: cast_nullable_to_non_nullable
+              as String,
+      productEnName: null == productEnName
+          ? _value.productEnName
+          : productEnName // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      price: null == price
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as double,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$PurchaseDataImplCopyWith<$Res>
+    implements $PurchaseDataCopyWith<$Res> {
+  factory _$$PurchaseDataImplCopyWith(
+          _$PurchaseDataImpl value, $Res Function(_$PurchaseDataImpl) then) =
+      __$$PurchaseDataImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {String merchantPaymentId,
+      String productName,
+      String productEnName,
+      String description,
+      double price});
+}
+
+/// @nodoc
+class __$$PurchaseDataImplCopyWithImpl<$Res>
+    extends _$PurchaseDataCopyWithImpl<$Res, _$PurchaseDataImpl>
+    implements _$$PurchaseDataImplCopyWith<$Res> {
+  __$$PurchaseDataImplCopyWithImpl(
+      _$PurchaseDataImpl _value, $Res Function(_$PurchaseDataImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? merchantPaymentId = null,
+    Object? productName = null,
+    Object? productEnName = null,
+    Object? description = null,
+    Object? price = null,
+  }) {
+    return _then(_$PurchaseDataImpl(
+      merchantPaymentId: null == merchantPaymentId
+          ? _value.merchantPaymentId
+          : merchantPaymentId // ignore: cast_nullable_to_non_nullable
+              as String,
+      productName: null == productName
+          ? _value.productName
+          : productName // ignore: cast_nullable_to_non_nullable
+              as String,
+      productEnName: null == productEnName
+          ? _value.productEnName
+          : productEnName // ignore: cast_nullable_to_non_nullable
+              as String,
+      description: null == description
+          ? _value.description
+          : description // ignore: cast_nullable_to_non_nullable
+              as String,
+      price: null == price
+          ? _value.price
+          : price // ignore: cast_nullable_to_non_nullable
+              as double,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$PurchaseDataImpl implements _PurchaseData {
+  const _$PurchaseDataImpl(
+      {required this.merchantPaymentId,
+      required this.productName,
+      required this.productEnName,
+      required this.description,
+      required this.price});
+
+  factory _$PurchaseDataImpl.fromJson(Map<String, dynamic> json) =>
+      _$$PurchaseDataImplFromJson(json);
+
+  @override
+  final String merchantPaymentId;
+  @override
+  final String productName;
+  @override
+  final String productEnName;
+  @override
+  final String description;
+  @override
+  final double price;
+
+  @override
+  String toString() {
+    return 'PurchaseData(merchantPaymentId: $merchantPaymentId, productName: $productName, productEnName: $productEnName, description: $description, price: $price)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$PurchaseDataImpl &&
+            (identical(other.merchantPaymentId, merchantPaymentId) ||
+                other.merchantPaymentId == merchantPaymentId) &&
+            (identical(other.productName, productName) ||
+                other.productName == productName) &&
+            (identical(other.productEnName, productEnName) ||
+                other.productEnName == productEnName) &&
+            (identical(other.description, description) ||
+                other.description == description) &&
+            (identical(other.price, price) || other.price == price));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, merchantPaymentId, productName,
+      productEnName, description, price);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$PurchaseDataImplCopyWith<_$PurchaseDataImpl> get copyWith =>
+      __$$PurchaseDataImplCopyWithImpl<_$PurchaseDataImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$PurchaseDataImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _PurchaseData implements PurchaseData {
+  const factory _PurchaseData(
+      {required final String merchantPaymentId,
+      required final String productName,
+      required final String productEnName,
+      required final String description,
+      required final double price}) = _$PurchaseDataImpl;
+
+  factory _PurchaseData.fromJson(Map<String, dynamic> json) =
+      _$PurchaseDataImpl.fromJson;
+
+  @override
+  String get merchantPaymentId;
+  @override
+  String get productName;
+  @override
+  String get productEnName;
+  @override
+  String get description;
+  @override
+  double get price;
+  @override
+  @JsonKey(ignore: true)
+  _$$PurchaseDataImplCopyWith<_$PurchaseDataImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/payment/domain/purchase_data.g.dart
+++ b/lib/feature/payment/domain/purchase_data.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'purchase_data.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$PurchaseDataImpl _$$PurchaseDataImplFromJson(Map<String, dynamic> json) =>
+    _$PurchaseDataImpl(
+      merchantPaymentId: json['merchantPaymentId'] as String,
+      productName: json['productName'] as String,
+      productEnName: json['productEnName'] as String,
+      description: json['description'] as String,
+      price: (json['price'] as num).toDouble(),
+    );
+
+Map<String, dynamic> _$$PurchaseDataImplToJson(_$PurchaseDataImpl instance) =>
+    <String, dynamic>{
+      'merchantPaymentId': instance.merchantPaymentId,
+      'productName': instance.productName,
+      'productEnName': instance.productEnName,
+      'description': instance.description,
+      'price': instance.price,
+    };

--- a/lib/feature/payment/domain/transition_url.dart
+++ b/lib/feature/payment/domain/transition_url.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'transition_url.freezed.dart';
+part 'transition_url.g.dart';
+
+@freezed
+class TransitionUrl with _$TransitionUrl {
+  const factory TransitionUrl({
+    required String transitionUrl,
+  }) = _TransitionUrl;
+
+  factory TransitionUrl.fromJson(Map<String, dynamic> json) =>
+      _$TransitionUrlFromJson(json);
+}

--- a/lib/feature/payment/domain/transition_url.freezed.dart
+++ b/lib/feature/payment/domain/transition_url.freezed.dart
@@ -1,0 +1,153 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'transition_url.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+TransitionUrl _$TransitionUrlFromJson(Map<String, dynamic> json) {
+  return _TransitionUrl.fromJson(json);
+}
+
+/// @nodoc
+mixin _$TransitionUrl {
+  String get transitionUrl => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $TransitionUrlCopyWith<TransitionUrl> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $TransitionUrlCopyWith<$Res> {
+  factory $TransitionUrlCopyWith(
+          TransitionUrl value, $Res Function(TransitionUrl) then) =
+      _$TransitionUrlCopyWithImpl<$Res, TransitionUrl>;
+  @useResult
+  $Res call({String transitionUrl});
+}
+
+/// @nodoc
+class _$TransitionUrlCopyWithImpl<$Res, $Val extends TransitionUrl>
+    implements $TransitionUrlCopyWith<$Res> {
+  _$TransitionUrlCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transitionUrl = null,
+  }) {
+    return _then(_value.copyWith(
+      transitionUrl: null == transitionUrl
+          ? _value.transitionUrl
+          : transitionUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$TransitionUrlImplCopyWith<$Res>
+    implements $TransitionUrlCopyWith<$Res> {
+  factory _$$TransitionUrlImplCopyWith(
+          _$TransitionUrlImpl value, $Res Function(_$TransitionUrlImpl) then) =
+      __$$TransitionUrlImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call({String transitionUrl});
+}
+
+/// @nodoc
+class __$$TransitionUrlImplCopyWithImpl<$Res>
+    extends _$TransitionUrlCopyWithImpl<$Res, _$TransitionUrlImpl>
+    implements _$$TransitionUrlImplCopyWith<$Res> {
+  __$$TransitionUrlImplCopyWithImpl(
+      _$TransitionUrlImpl _value, $Res Function(_$TransitionUrlImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? transitionUrl = null,
+  }) {
+    return _then(_$TransitionUrlImpl(
+      transitionUrl: null == transitionUrl
+          ? _value.transitionUrl
+          : transitionUrl // ignore: cast_nullable_to_non_nullable
+              as String,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$TransitionUrlImpl implements _TransitionUrl {
+  const _$TransitionUrlImpl({required this.transitionUrl});
+
+  factory _$TransitionUrlImpl.fromJson(Map<String, dynamic> json) =>
+      _$$TransitionUrlImplFromJson(json);
+
+  @override
+  final String transitionUrl;
+
+  @override
+  String toString() {
+    return 'TransitionUrl(transitionUrl: $transitionUrl)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$TransitionUrlImpl &&
+            (identical(other.transitionUrl, transitionUrl) ||
+                other.transitionUrl == transitionUrl));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, transitionUrl);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$TransitionUrlImplCopyWith<_$TransitionUrlImpl> get copyWith =>
+      __$$TransitionUrlImplCopyWithImpl<_$TransitionUrlImpl>(this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$TransitionUrlImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _TransitionUrl implements TransitionUrl {
+  const factory _TransitionUrl({required final String transitionUrl}) =
+      _$TransitionUrlImpl;
+
+  factory _TransitionUrl.fromJson(Map<String, dynamic> json) =
+      _$TransitionUrlImpl.fromJson;
+
+  @override
+  String get transitionUrl;
+  @override
+  @JsonKey(ignore: true)
+  _$$TransitionUrlImplCopyWith<_$TransitionUrlImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/feature/payment/domain/transition_url.g.dart
+++ b/lib/feature/payment/domain/transition_url.g.dart
@@ -1,0 +1,17 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'transition_url.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$TransitionUrlImpl _$$TransitionUrlImplFromJson(Map<String, dynamic> json) =>
+    _$TransitionUrlImpl(
+      transitionUrl: json['transitionUrl'] as String,
+    );
+
+Map<String, dynamic> _$$TransitionUrlImplToJson(_$TransitionUrlImpl instance) =>
+    <String, dynamic>{
+      'transitionUrl': instance.transitionUrl,
+    };

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,6 +38,10 @@ dependencies:
   # UI
   gap: ^3.0.1
 
+  # Util
+  http: ^1.2.1
+  url_launcher: ^6.2.6
+
 dev_dependencies:
   # テスト
   flutter_test:


### PR DESCRIPTION
## 概要
アプリから PayPay 決済画面に遷移する実装

### まだやってないこと
- リダイレクト処理
- Firestore に決済情報の保存

### メモ
ブラウザからのリダイレクトに必要な情報がまとまっていない